### PR TITLE
Merge 'ligand-bond-creation' into combined

### DIFF
--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/PDBFileParser.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/PDBFileParser.java
@@ -2721,6 +2721,10 @@ COLUMNS   DATA TYPE         FIELD          DEFINITION
 		}
 
 
+		if (params.shouldCreateLigandConects()){
+			addLigandConnections();
+		}
+		
 
 		if ( params.isParseSecStruc())
 			setSecStruc();
@@ -2783,6 +2787,12 @@ COLUMNS   DATA TYPE         FIELD          DEFINITION
 
 		BondMaker maker = new BondMaker(structure);
 		maker.makeBonds();
+	}
+	
+	//Builds a list of connections from ligands in a Structure
+	private void addLigandConnections(){
+		LigandConnectMaker maker = new LigandConnectMaker(structure);
+		maker.addLigandConnections();
 	}
 	
 	private void formLinkRecordBond(LinkRecord linkRecord) {


### PR DESCRIPTION
The FileParsingParameter shouldCreateLigandConects dictates whether the
parser will add bond connections for ligands.
